### PR TITLE
chore: add gitignore and bump aiohelvar to 0.9.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+
+# Virtual environments
+venv/
+.venv/
+env/
+ENV/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Editor
+.vscode/
+.idea/
+.omc/
+*.swp
+*.swo
+*~
+
+# Home Assistant
+*.db
+*.db-shm
+*.db-wal
+
+# Secrets / local config
+secrets.yaml
+.env

--- a/custom_components/helvar/manifest.json
+++ b/custom_components/helvar/manifest.json
@@ -9,8 +9,8 @@
   "homekit": {},
   "iot_class": "local_push",
   "loggers": ["aiohelvar"],
-  "requirements": ["aiohelvar==0.9.7"],
+  "requirements": ["aiohelvar==0.9.8"],
   "ssdp": [],
-  "version": "0.2.2", 
+  "version": "0.2.3", 
   "zeroconf": []
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,5 +3,5 @@ pytest-asyncio>=0.21.0
 pytest-cov>=4.0.0
 pytest-mock>=3.10.0
 homeassistant>=2023.1.0
-aiohelvar==0.9.7
+aiohelvar==0.9.8
 


### PR DESCRIPTION
## Summary
Adds a .gitignore to stop Python bytecode, virtual environments, macOS metadata, and editor directories from appearing as untracked files. Also bumps the aiohelvar dependency to 0.9.8.

## Changes
- Add .gitignore covering Python, venv, pytest, macOS, editors, HA db files, and secrets
- Bump aiohelvar requirement to 0.9.8 in manifest.json and requirements-test.txt
- Bump integration version to 0.2.3

## Test Plan
- Verified git status shows expected files ignored after adding .gitignore